### PR TITLE
SIR-1836 - Set prefect to only run for Cloud-Native machines

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,9 @@ upload_channels: [pbp-testing]
 aggregate_check: false
 pbp_autopublish: true
 pbp_only_deployment: pre-prod
+# Don't depend on MacOS or Linux-s390x - speedier results
+use_prefect_platforms:
+    - linux-64
+    - linux-aarch64
+    - win-64
 


### PR DESCRIPTION
Related to SIR-1836.

Set the buildable platforms only to things that we currently have as cloud-native to improve turnaround time.