### PR TITLE
QA Test: Bump build number to 436

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
 source:
   path: ../src
 build:
-  number: 435
+  number: 436
 about:
   home: https://github.com/AnacondaRecipes/prefect-test-dependency-feedstock
   license_file: LICENSE


### PR DESCRIPTION
## Summary
- Bumped build number from 435 to 436 for QA testing
- Testing graph generation via PR (SIR-2529)

## Test Plan
- Verify TaskCluster triggers a build/graph without release task
- After merge, verify graph with release task is created