### PR TITLE
[automation] manual graph generation check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
 source:
   path: ../src
 build:
-  number: 465
+  number: 466
 about:
   home: https://github.com/AnacondaRecipes/prefect-test-dependency-feedstock
   license_file: LICENSE


### PR DESCRIPTION
Manual check (from Claude, authorized by aalvi) — bumps build number to test whether opening a PR triggers a build graph on pre-prod. Branch deleted after the check.