### PR TITLE
[automation] graph-submitter env check (QA)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
 source:
   path: ../src
 build:
-  number: 465
+  number: 466
 about:
   home: https://github.com/AnacondaRecipes/prefect-test-dependency-feedstock
   license_file: LICENSE


### PR DESCRIPTION
QA check (authorized by aalvi) — does opening a PR generate a build graph on pre-prod (package-build.anacondaconnect.com)? Referenced in a support question to the platform team about the graph-submitter not triggering on pre-prod. Safe to close/delete.