### PR TITLE
Enable 100% pre-prod graph submission for QA E2E feedstock

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,10 @@ upload_channels: [ad_package_build]
 aggregate_check: false
 pbp_autopublish: true
 pbp_only_deployment: pre-prod
+# Force 100% graph submission so this QA feedstock always generates a pre-prod
+# graph on PR open (overrides the 10% pre-prod downsampling from
+# anaconda/package-build-platform#3334). Required for the graph-generation-via-PR E2E.
+graph_submit_probability: 1
 # Don't depend on MacOS or Linux-s390x - speedier results
 use_prefect_platforms:
     - linux-64


### PR DESCRIPTION
## What
Adds `graph_submit_probability: 1` to this feedstock's root `abs.yaml`.

## Why
Since ~2026-07-22, opening a PR on this feedstock stopped reliably generating a build graph on **pre-prod** (`package-build.anacondaconnect.com`), so our **Graph Generation via PR** E2E test times out.

Root cause: anaconda/package-build-platform#3334 set the pre-prod graph-submission probability to **0.1 (10%)**. This feedstock is pinned to pre-prod only (`pbp_only_deployment: pre-prod`), so pre-prod is its only path — meaning ~90% of PRs now produce no graph at all. (Normal feedstocks are unaffected because prod stays at 100%.)

The graph-submitter supports a per-feedstock override via the root `abs.yaml` key `graph_submit_probability` (see `services/gh-webhook/graph-submitter-function/app/graph_sampling.py`). Setting it to `1` forces this QA feedstock to always submit to pre-prod, restoring deterministic E2E behavior. This is the documented, intended use of the override (SIR-3027) and does not affect any other feedstock.

## Test
After merge, opening a PR on this feedstock should generate a pre-prod graph on every run (verified the mechanism via test PRs #69/#70, which currently only reach prod).

cc platform team for review.