### PR TITLE
[manual] graph-submitter check — verifying pre-prod graph creation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ source:
   path: ../src
 
 build:
-  number: 482
+  number: 483
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
 


### PR DESCRIPTION
Manual PR to observe the pre-prod graph-submitter end to end.

Context: the graph-generation-via-PR E2E reports no graph appearing for its PRs, yet the submitter posts `success — Submitted for prefect-test-dependency-feedstock`. Per `main.py` that message is only used when `submit_to_orchestrator` is true, so the 10% pre-prod downsampling (SIR-3594) is **not** the cause here — `graph_submit_probability: 1` in abs.yaml is being honoured. Submission is attempted and no graph appears in pkg-orchestrator.

Raised by hand so the behaviour can be inspected directly. Please leave open for review; not intended to merge.