### PR TITLE
QA: verify preprod graph submission (build 484)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ source:
   path: ../src
 
 build:
-  number: 482
+  number: 484
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
 


### PR DESCRIPTION
Diagnostic PR for the preprod graph-submitter investigation. Bumps the build number only.

`abs.yaml` sets `pbp_only_deployment: pre-prod` and `graph_submit_probability: 1`, so this PR should produce a graph in **preprod**. Checking whether it does.

Please leave open — will close once observed.